### PR TITLE
:recycle: Remove library requirements from conanfile

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -26,15 +26,12 @@ class libhal_display_conan(ConanFile):
     topics = ("display", "libhal", "driver")
     settings = "compiler", "build_type", "os", "arch"
 
-    python_requires = "libhal-bootstrap/[^4.0.0]"
+    python_requires = "libhal-bootstrap/[^4.1.0]"
     python_requires_extend = "libhal-bootstrap.library"
 
     def requirements(self):
-        # Adds libhal and libhal-util as transitive headers, meaning library
-        # consumers get the libhal and libhal-util headers downstream.
-        bootstrap = self.python_requires["libhal-bootstrap"]
-        bootstrap.module.add_library_requirements(
-            self, override_libhal_util_version="5.3.0")
+        self.requires("libhal/[^4.9.0]", transitive_headers=True)
+        self.requires("libhal-util/[^5.3.0]", transitive_headers=True)
 
     def package_info(self):
         self.cpp_info.libs = ["libhal-display"]


### PR DESCRIPTION
Planning to deprecate/remove this function as its not very helpful and the "override" parameter, even if short, would be annoying to remember.